### PR TITLE
feat: support visualstudio.com organization URLs for System.AccessToken

### DIFF
--- a/CopilotCodeReviewV1/index.ts
+++ b/CopilotCodeReviewV1/index.ts
@@ -108,8 +108,8 @@ async function run(): Promise<void> {
 
         // Auto-detect organization from System.CollectionUri if not provided
         // CollectionUri format: https://dev.azure.com/orgname/ or https://orgname.visualstudio.com/
+        const collectionUri = tl.getVariable('System.CollectionUri');
         if (!organization) {
-            const collectionUri = tl.getVariable('System.CollectionUri');
             if (collectionUri) {
                 const devAzureMatch = collectionUri.match(/https:\/\/dev\.azure\.com\/([^\/]+)/);
                 const vstsMatch = collectionUri.match(/https:\/\/([^\.]+)\.visualstudio\.com/);
@@ -122,6 +122,13 @@ async function run(): Promise<void> {
                 }
             }
         }
+
+        // Determine the collection URI base URL for API calls.
+        // This ensures OAuth tokens scoped to visualstudio.com work correctly
+        // instead of always using https://dev.azure.com (#22).
+        const orgBaseUrl = collectionUri
+            ? collectionUri.replace(/\/+$/, '')
+            : `https://dev.azure.com/${organization}`;
 
         if (!organization) {
             tl.setResult(tl.TaskResult.Failed, 'Organization is required. Either provide it as an input or ensure System.CollectionUri is available.');
@@ -159,6 +166,7 @@ async function run(): Promise<void> {
         console.log('Copilot Code Review Task');
         console.log('='.repeat(60));
         console.log(`Organization: ${organization}`);
+        console.log(`Collection URI: ${orgBaseUrl}`);
         console.log(`Project: ${project}`);
         console.log(`Repository: ${repository}`);
         console.log(`Pull Request ID: ${pullRequestId}`);
@@ -172,6 +180,7 @@ async function run(): Promise<void> {
         process.env['GH_TOKEN'] = githubPat;
         process.env['AZUREDEVOPS_TOKEN'] = azureDevOpsToken;
         process.env['AZUREDEVOPS_AUTH_TYPE'] = azureDevOpsAuthType;
+        process.env['AZUREDEVOPS_COLLECTION_URI'] = orgBaseUrl;
         process.env['ORGANIZATION'] = organization;
         process.env['PROJECT'] = project;
         process.env['REPOSITORY'] = repository;
@@ -199,6 +208,7 @@ async function run(): Promise<void> {
             `-Token "${azureDevOpsToken}"`,
             `-AuthType "${azureDevOpsAuthType}"`,
             `-Organization "${organization}"`,
+            `-CollectionUri "${orgBaseUrl}"`,
             `-Project "${project}"`,
             `-Repository "${repository}"`,
             `-Id ${pullRequestId}`,
@@ -215,6 +225,7 @@ async function run(): Promise<void> {
             `-Token "${azureDevOpsToken}"`,
             `-AuthType "${azureDevOpsAuthType}"`,
             `-Organization "${organization}"`,
+            `-CollectionUri "${orgBaseUrl}"`,
             `-Project "${project}"`,
             `-Repository "${repository}"`,
             `-Id ${pullRequestId}`,

--- a/CopilotCodeReviewV1/package-lock.json
+++ b/CopilotCodeReviewV1/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "copilot-code-review-task",
-    "version": "1.0.12",
+    "version": "1.4.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "copilot-code-review-task",
-            "version": "1.0.12",
+            "version": "1.4.2",
             "license": "MIT",
             "dependencies": {
                 "azure-pipelines-task-lib": "^4.17.3",

--- a/CopilotCodeReviewV1/scripts/Add-AzureDevOpsPRComment.ps1
+++ b/CopilotCodeReviewV1/scripts/Add-AzureDevOpsPRComment.ps1
@@ -95,6 +95,9 @@ param(
     [ValidateNotNullOrEmpty()]
     [string]$Organization,
 
+    [Parameter(Mandatory = $false, HelpMessage = "Azure DevOps collection URI (e.g., https://dev.azure.com/org or https://org.visualstudio.com)")]
+    [string]$CollectionUri,
+
     [Parameter(Mandatory = $true, HelpMessage = "Azure DevOps project name")]
     [ValidateNotNullOrEmpty()]
     [string]$Project,
@@ -229,7 +232,8 @@ function Format-AzureDevOpsFilePath {
 #region Main Logic
 
 $headers = Get-AuthorizationHeader -Token $Token -AuthType $AuthType
-$baseUrl = "https://dev.azure.com/$Organization/$Project/_apis/git/repositories/$Repository/pullrequests/$Id"
+$orgBaseUrl = if ($CollectionUri) { $CollectionUri } else { "https://dev.azure.com/$Organization" }
+$baseUrl = "$orgBaseUrl/$Project/_apis/git/repositories/$Repository/pullrequests/$Id"
 $apiVersion = "api-version=7.1"
 
 # First, verify the PR exists
@@ -401,7 +405,7 @@ else {
 }
 
 # Provide link to the PR
-$webUrl = "https://dev.azure.com/$Organization/$Project/_git/$Repository/pullrequest/$Id"
+$webUrl = "$orgBaseUrl/$Project/_git/$Repository/pullrequest/$Id"
 Write-Host "`nView PR: $webUrl" -ForegroundColor Cyan
 
 #endregion

--- a/CopilotCodeReviewV1/scripts/Add-CopilotComment.ps1
+++ b/CopilotCodeReviewV1/scripts/Add-CopilotComment.ps1
@@ -88,6 +88,11 @@ $params = @{
     Status       = $Status
 }
 
+# Pass collection URI if available (supports both dev.azure.com and visualstudio.com)
+if (${env:AZUREDEVOPS_COLLECTION_URI}) {
+    $params.CollectionUri = ${env:AZUREDEVOPS_COLLECTION_URI}
+}
+
 # Add inline comment parameters if file path is provided
 if ($FilePath) {
     $params.FilePath = $FilePath

--- a/CopilotCodeReviewV1/scripts/Delete-CopilotComment.ps1
+++ b/CopilotCodeReviewV1/scripts/Delete-CopilotComment.ps1
@@ -54,6 +54,7 @@ try {
     # Read credentials from environment variables
     $token = ${env:AZUREDEVOPS_TOKEN}
     $authType = ${env:AZUREDEVOPS_AUTH_TYPE}
+    $collectionUri = ${env:AZUREDEVOPS_COLLECTION_URI}
     $organization = ${env:ORGANIZATION}
     $project = ${env:PROJECT}
     $repository = ${env:REPOSITORY}
@@ -90,7 +91,8 @@ try {
     }
 
     # Build the API URL for deleting a comment
-    $baseUrl = "https://dev.azure.com/$organization/$project/_apis"
+    $orgBaseUrl = if ($collectionUri) { $collectionUri } else { "https://dev.azure.com/$organization" }
+    $baseUrl = "$orgBaseUrl/$project/_apis"
     $uri = "$baseUrl/git/repositories/$repository/pullrequests/$prId/threads/$ThreadId/comments/$CommentId`?api-version=7.1"
 
     # Send DELETE request

--- a/CopilotCodeReviewV1/scripts/Get-AzureDevOpsPR.ps1
+++ b/CopilotCodeReviewV1/scripts/Get-AzureDevOpsPR.ps1
@@ -69,6 +69,9 @@ param(
     [ValidateNotNullOrEmpty()]
     [string]$Organization,
 
+    [Parameter(Mandatory = $false, HelpMessage = "Azure DevOps collection URI (e.g., https://dev.azure.com/org or https://org.visualstudio.com)")]
+    [string]$CollectionUri,
+
     [Parameter(Mandatory = $true, HelpMessage = "Azure DevOps project name")]
     [ValidateNotNullOrEmpty()]
     [string]$Project,
@@ -275,7 +278,8 @@ $script:OutputToFile = -not [string]::IsNullOrEmpty($OutputFile)
 $script:OutputBuilder = [System.Text.StringBuilder]::new()
 
 $headers = Get-AuthorizationHeader -Token $Token -AuthType $AuthType
-$baseUrl = "https://dev.azure.com/$Organization/$Project/_apis"
+$orgBaseUrl = if ($CollectionUri) { $CollectionUri } else { "https://dev.azure.com/$Organization" }
+$baseUrl = "$orgBaseUrl/$Project/_apis"
 $apiVersion = "api-version=7.1"
 
 # If a specific PR ID is provided, get detailed information
@@ -487,7 +491,7 @@ if ($Id -gt 0) {
     }
     
     Write-Output-Line "`n[Links]" -ForegroundColor Yellow
-    $webUrl = "https://dev.azure.com/$Organization/$Project/_git/$($pr.repository.name)/pullrequest/$($pr.pullRequestId)"
+    $webUrl = "$orgBaseUrl/$Project/_git/$($pr.repository.name)/pullrequest/$($pr.pullRequestId)"
     Write-Output-Line "  Web URL: $webUrl"
     
     Write-Output-Line ("`n" + ("=" * 80)) -ForegroundColor DarkGray

--- a/CopilotCodeReviewV1/scripts/Get-AzureDevOpsPRChanges.ps1
+++ b/CopilotCodeReviewV1/scripts/Get-AzureDevOpsPRChanges.ps1
@@ -57,6 +57,9 @@ param(
     [ValidateNotNullOrEmpty()]
     [string]$Organization,
 
+    [Parameter(Mandatory = $false, HelpMessage = "Azure DevOps collection URI (e.g., https://dev.azure.com/org or https://org.visualstudio.com)")]
+    [string]$CollectionUri,
+
     [Parameter(Mandatory = $true, HelpMessage = "Azure DevOps project name")]
     [ValidateNotNullOrEmpty()]
     [string]$Project,
@@ -186,7 +189,8 @@ $script:OutputToFile = -not [string]::IsNullOrEmpty($OutputFile)
 $script:OutputBuilder = [System.Text.StringBuilder]::new()
 
 $headers = Get-AuthorizationHeader -Token $Token -AuthType $AuthType
-$baseUrl = "https://dev.azure.com/$Organization/$Project/_apis/git/repositories/$Repository/pullrequests/$Id"
+$orgBaseUrl = if ($CollectionUri) { $CollectionUri } else { "https://dev.azure.com/$Organization" }
+$baseUrl = "$orgBaseUrl/$Project/_apis/git/repositories/$Repository/pullrequests/$Id"
 $apiVersion = "api-version=7.1"
 
 # Verify the PR exists
@@ -299,7 +303,7 @@ else {
 Write-Output-Line ("`n" + ("=" * 80)) -ForegroundColor DarkGray
 
 # Provide link to the PR
-$webUrl = "https://dev.azure.com/$Organization/$Project/_git/$Repository/pullrequest/$Id"
+$webUrl = "$orgBaseUrl/$Project/_git/$Repository/pullrequest/$Id"
 Write-Host "`nView PR: $webUrl" -ForegroundColor Cyan
 if ($script:OutputToFile) {
     $script:OutputBuilder.AppendLine("`nView PR: $webUrl") | Out-Null

--- a/CopilotCodeReviewV1/scripts/Update-CopilotComment.ps1
+++ b/CopilotCodeReviewV1/scripts/Update-CopilotComment.ps1
@@ -86,6 +86,7 @@ try {
     # Read credentials from environment variables
     $token = ${env:AZUREDEVOPS_TOKEN}
     $authType = ${env:AZUREDEVOPS_AUTH_TYPE}
+    $collectionUri = ${env:AZUREDEVOPS_COLLECTION_URI}
     $organization = ${env:ORGANIZATION}
     $project = ${env:PROJECT}
     $repository = ${env:REPOSITORY}
@@ -121,7 +122,8 @@ try {
         }
     }
 
-    $baseUrl = "https://dev.azure.com/$organization/$project/_apis"
+    $orgBaseUrl = if ($collectionUri) { $collectionUri } else { "https://dev.azure.com/$organization" }
+    $baseUrl = "$orgBaseUrl/$project/_apis"
 
     # Update thread status if specified
     if (-not [string]::IsNullOrEmpty($Status)) {

--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Verify that:
   - The token is not expired
 - If using `useSystemAccessToken`:
   - The Build Service identity has **"Contribute to pull requests"** permission on the repository
+  - Both `https://dev.azure.com/{org}` and legacy `https://{org}.visualstudio.com` organization URLs are supported automatically. The task uses `System.CollectionUri` to determine the correct API endpoint for OAuth token authentication.
   - Try explicitly mapping the `SYSTEM_ACCESSTOKEN` environment variable:
 
 ```yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,13 @@
 {
-  "name": "ado-copilot-code-review",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
+    "name": "ado-copilot-code-review",
+    "version": "1.5.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "ado-copilot-code-review",
+            "version": "1.5.0",
+            "license": "GPL-3.0"
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Ref #22

When Azure DevOps organizations use the legacy `https://{org}.visualstudio.com` URL format, the `System.AccessToken` (OAuth Bearer token) is scoped to that domain. Previously, all API calls were hardcoded to `https://dev.azure.com/{org}`, causing Bearer token authentication to fail with a "permission denied" error when using `useSystemAccessToken: true`.

This change:
- Derives the API base URL from `System.CollectionUri` instead of hardcoding `https://dev.azure.com`
- Passes it as `AZUREDEVOPS_COLLECTION_URI` environment variable to all PowerShell scripts
- Falls back to `https://dev.azure.com/{org}` when the variable is not set (fully backward compatible)

## What changed

| File | Change |
|------|--------|
| `index.ts` | Read `System.CollectionUri`, set `AZUREDEVOPS_COLLECTION_URI` env var, pass `-CollectionUri` to scripts |
| `Get-AzureDevOpsPR.ps1` | Add `$CollectionUri` param, use for API/web URL construction |
| `Get-AzureDevOpsPRChanges.ps1` | Add `$CollectionUri` param, use for API/web URL construction |
| `Add-AzureDevOpsPRComment.ps1` | Add `$CollectionUri` param, use for API/web URL construction |
| `Add-CopilotComment.ps1` | Forward `AZUREDEVOPS_COLLECTION_URI` env var to `Add-AzureDevOpsPRComment` |
| `Update-CopilotComment.ps1` | Read env var, use for URL construction |
| `Delete-CopilotComment.ps1` | Read env var, use for URL construction |
| `README.md` | Document support for both URL formats |

## Test plan

- [ ] Pipeline with `https://dev.azure.com/{org}` org URL + `useSystemAccessToken: true` still works
- [ ] Pipeline with `https://{org}.visualstudio.com` org URL + `useSystemAccessToken: true` now posts PR comments successfully
- [ ] Pipeline with `azureDevOpsPat` (Basic auth) still works regardless of URL format
- [ ] Backward compatible: no new required inputs, no breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
