### PR TITLE
Be more specific with what's the base commit SHA and what's the delta to be reviewed, i.e. the PR commit SHA

### DIFF
--- a/CopilotCodeReviewV1/scripts/Get-AzureDevOpsPRChanges.ps1
+++ b/CopilotCodeReviewV1/scripts/Get-AzureDevOpsPRChanges.ps1
@@ -3,7 +3,7 @@
     Retrieves commits and changed files from the most recent iteration of a pull request.
 
 .DESCRIPTION
-    This script uses the Azure DevOps REST API to get the list of commits and 
+    This script uses the Azure DevOps REST API to get the list of commits and
     changed files from the most recent iteration (latest push) of a pull request.
 
 .PARAMETER Token
@@ -81,7 +81,7 @@ function Write-Output-Line {
         [string]$ForegroundColor = "White",
         [switch]$NoNewline
     )
-    
+
     if ($script:OutputToFile) {
         if ($NoNewline) {
             $script:OutputBuilder.Append($Message) | Out-Null
@@ -90,7 +90,7 @@ function Write-Output-Line {
             $script:OutputBuilder.AppendLine($Message) | Out-Null
         }
     }
-    
+
     if ($NoNewline) {
         Write-Host $Message -ForegroundColor $ForegroundColor -NoNewline
     }
@@ -104,7 +104,7 @@ function Get-AuthorizationHeader {
         [string]$Token,
         [string]$AuthType = "Basic"
     )
-    
+
     if ($AuthType -eq "Bearer") {
         return @{
             Authorization  = "Bearer $Token"
@@ -126,7 +126,7 @@ function Invoke-AzureDevOpsApi {
         [hashtable]$Headers,
         [string]$Method = "Get"
     )
-    
+
     try {
         $response = Invoke-RestMethod -Uri $Uri -Headers $Headers -Method $Method -ErrorAction Stop
         return $response
@@ -167,11 +167,11 @@ function Invoke-AzureDevOpsApi {
 
 function Format-DateForDisplay {
     param([string]$DateString)
-    
+
     if ([string]::IsNullOrEmpty($DateString)) {
         return "N/A"
     }
-    
+
     try {
         $date = [DateTime]::Parse($DateString)
         return $date.ToString("yyyy-MM-dd HH:mm:ss")
@@ -183,7 +183,7 @@ function Format-DateForDisplay {
 
 function Get-ChangeTypeDisplay {
     param([string]$ChangeType)
-    
+
     switch ($ChangeType) {
         "add"      { return @{ Text = "Added"; Color = "Green" } }
         "edit"     { return @{ Text = "Modified"; Color = "Yellow" } }
@@ -255,17 +255,17 @@ Write-Output-Line "  Iteration ID:     #$iterationId"
 Write-Output-Line "  Created:          $(Format-DateForDisplay $latestIteration.createdDate)"
 Write-Output-Line "  Updated:          $(Format-DateForDisplay $latestIteration.updatedDate)"
 if ($latestIteration.sourceRefCommit) {
-    Write-Output-Line "  Source Commit:    $($latestIteration.sourceRefCommit.commitId.Substring(0, 8))"
+    Write-Output-Line "  PR Branch Commit (new code):   $($latestIteration.sourceRefCommit.commitId)"
 }
 if ($latestIteration.targetRefCommit) {
-    Write-Output-Line "  Target Commit:    $($latestIteration.targetRefCommit.commitId.Substring(0, 8))"
+    Write-Output-Line "  Base Branch Commit (old code): $($latestIteration.targetRefCommit.commitId)"
 }
 
 # Commits
 Write-Output-Line "`n[Commits in this PR]" -ForegroundColor Yellow
 if ($commits -and $commits.value -and $commits.value.Count -gt 0) {
     Write-Output-Line "  Total commits: $($commits.value.Count)`n"
-    
+
     foreach ($commit in $commits.value) {
         $shortId = $commit.commitId.Substring(0, 8)
         $message = $commit.comment -split "`n" | Select-Object -First 1
@@ -288,7 +288,7 @@ if ($changes -and $changes.changeEntries -and $changes.changeEntries.Count -gt 0
     $modifiedCount = ($changes.changeEntries | Where-Object { $_.changeType -eq "edit" }).Count
     $deletedCount = ($changes.changeEntries | Where-Object { $_.changeType -eq "delete" }).Count
     $otherCount = $changes.changeEntries.Count - $addedCount - $modifiedCount - $deletedCount
-    
+
     Write-Output-Line "  Total files changed: $($changes.changeEntries.Count)"
     $summaryLine = "  +$addedCount added | ~$modifiedCount modified | -$deletedCount deleted"
     if ($otherCount -gt 0) {
@@ -296,14 +296,14 @@ if ($changes -and $changes.changeEntries -and $changes.changeEntries.Count -gt 0
     }
     Write-Output-Line $summaryLine
     Write-Output-Line ""
-    
+
     # List each file
     foreach ($change in $changes.changeEntries) {
         $changeDisplay = Get-ChangeTypeDisplay -ChangeType $change.changeType
         $filePath = $change.item.path
-        
+
         Write-Output-Line "  [$($changeDisplay.Text)] $filePath" -ForegroundColor $changeDisplay.Color
-        
+
         # Show original path for renames
         if ($change.changeType -eq "rename" -and $change.originalPath) {
             Write-Output-Line "         (from: $($change.originalPath))" -ForegroundColor DarkGray
@@ -332,7 +332,7 @@ if ($script:OutputToFile) {
         }
         $script:OutputBuilder.ToString() | Out-File -FilePath $OutputFile -Encoding UTF8
         Write-Host "`nOutput written to: $OutputFile" -ForegroundColor Green
-        
+
         # Also write the iteration ID to a separate file for use by other scripts
         $iterationIdFile = Join-Path $outputDir "Iteration_Id.txt"
         $iterationId.ToString() | Out-File -FilePath $iterationIdFile -Encoding UTF8 -NoNewline

--- a/CopilotCodeReviewV1/scripts/prompt.txt
+++ b/CopilotCodeReviewV1/scripts/prompt.txt
@@ -4,23 +4,23 @@ For this task, you will take on the role of a senior engineer performing a code 
 
 # Guidelines
 
-Using this information along with git commands and the local copy of the repository, please conduct a code review of this pull request and identify any suggested modifications that should be made. All feedback should fall within the following constraints:
+Using this information along with git commands and the local copy of the repository, please conduct a code review of this pull request and identify any suggested modifications that should be made. The Iteration_Details.txt file contains the commit SHAs labelled "PR Branch Commit (new code)" and "Base Branch Commit (old code)". To see what the PR changed, always run git diff in the direction: `git diff <base-branch-commit> <pr-branch-commit>` — i.e. base (old) first, PR branch (new) second. This ensures additions in the diff represent code added by the PR and deletions represent code removed by the PR. All feedback should fall within the following constraints:
 
-- Feedback should be limited ONLY to the file sections that have been changed or program functions that are directly impacted by the changed code. 
+- Feedback should be limited ONLY to the file sections that have been changed or program functions that are directly impacted by the changed code.
 
 - DO NOT suggest modifications for pre-existing code that was not directly modified or negatively impacted by the changes in the PR.
 
 - If the changes were comprised largely of refactoring or organizational changes, limit raised issues to any newly introduced bugs or performance degradation.
 
-- Suggestions should fall within these areas of concern: performance, safety, reusability, simplification, and security. Points related to maintainability and code consistency may also be raised, but ONLY if the changes have diverged significantly from the standards of the codebase. 
+- Suggestions should fall within these areas of concern: performance, safety, reusability, simplification, and security. Points related to maintainability and code consistency may also be raised, but ONLY if the changes have diverged significantly from the standards of the codebase.
 
-- Matters of preference or style that do not make a discernible difference from a human's perspective should NOT be included in the suggested changes. 
+- Matters of preference or style that do not make a discernible difference from a human's perspective should NOT be included in the suggested changes.
 
-- Positive feedback for thoughtful solutions or high-impact additions may be included, but avoid over-praising or becoming sycophantic. 
+- Positive feedback for thoughtful solutions or high-impact additions may be included, but avoid over-praising or becoming sycophantic.
 
 # Updating Feedback State
 
-The PR_Details.txt file will contain an overview of any existing comments on the PR—any new feedback you provide should NOT overlap with existing feedback. 
+The PR_Details.txt file will contain an overview of any existing comments on the PR—any new feedback you provide should NOT overlap with existing feedback.
 
 The PR_Details.txt file may contain a JSON section titled "COPILOT COMMENT THREADS (JSON)" listing comment threads from previous Copilot reviews. Each thread includes a `status` field (e.g., "active", "fixed", "closed"), the full comment text in `content`, and a `replies` array containing any threaded replies with their author, content, and publishedDate. For each thread with an "active" status, evaluate whether the underlying issue has been addressed in the current iteration's changes—consider both the code diff and any reply context. If the issue has been resolved, first post a brief reply to the thread explaining what was addressed, then mark the thread as fixed. This two-step process ensures there is a clear audit trail showing the thread was resolved by the automated review rather than a developer.
 


### PR DESCRIPTION
We noticed that without this change, sometimes the AI tool reviewed the delta from newer to older commit, which led it to misinterpret a bug as a fix.